### PR TITLE
fix(min-rate): set minimum rate to 1 bps

### DIFF
--- a/src/SpeedJumpIrm.sol
+++ b/src/SpeedJumpIrm.sol
@@ -30,8 +30,8 @@ contract AdaptativeCurveIrm is IIrm {
 
     /// @notice Maximum rate at target per second (scaled by WAD) (1B% APR).
     uint256 public constant MAX_RATE_AT_TARGET = uint256(0.01e9 ether) / 365 days;
-    /// @notice Mininimum rate at target per second (scaled by WAD) (0.1% APR).
-    uint256 public constant MIN_RATE_AT_TARGET = uint256(0.001 ether) / 365 days;
+    /// @notice Mininimum rate at target per second (scaled by WAD) (0.01% APR).
+    uint256 public constant MIN_RATE_AT_TARGET = uint256(0.0001 ether) / 365 days;
     /// @notice Address of Morpho.
     address public immutable MORPHO;
     /// @notice Curve steepness (scaled by WAD).


### PR DESCRIPTION
Let's suppose the worst case scenario of a market not utilized for so long that the rate reached `MIN_RATE_AT_TARGET` and suddenly it is utilized 100%

So  `err = 1` because `utilization = 100%`

And we can calculate that: $r_{t+1} = c \times min_{rate} \times e^{adjSpeed \times elapsed}$

Which leads $elapsed = ln(\frac{r_{t+1}}{c \times min_{rate}}) \times \frac{1}{adjSpeed}$

Let's now plot $elapsed$ (in days) based on different values of $r_{t+1}$ and $c$:

| $r_{t+1}$ \ $c$ | 1    | 1.5  | 2    | 4    | 5    | 6    | 8    | 10   |
|-------------|------|------|------|------|------|------|------|------|
| 0.01%       | 0    | 0    | 0    | 0    | 0    | 0    | 0    | 0    |
| 0.1%        | 16.8 | 13.9 | 11.8 | 6.7  | 5.1  | 3.7  | 1.6  | 0    |
| 1%          | 33.6 | 30.7 | 28.6 | 23.5 | 21.9 | 20.5 | 18.4 | 16.8 |
| 10%         | 50.4 | 47.5 | 45.4 | 40.3 | 38.7 | 37.3 | 35.2 | 33.6 |